### PR TITLE
Add integrated OMR generation and processing test

### DIFF
--- a/omr_processor2.py
+++ b/omr_processor2.py
@@ -1,0 +1,487 @@
+#!/usr/bin/env python3
+"""OMR sheet processor for images captured from generated answer sheets.
+
+This script rectifies a photographed OMR sheet, evaluates bubble fill levels,
+infers the roll number and marked answers, and optionally saves debug images
+and JSON summaries.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Dict, List, Tuple
+
+import cv2
+import numpy as np
+
+
+@dataclass
+class Bubble:
+    """Represents a single bubble on the OMR sheet."""
+
+    kind: str  # "roll" or "question"
+    center: Tuple[int, int]
+    radius: int
+    metadata: Dict[str, int | str] = field(default_factory=dict)
+    score: float = 0.0
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Process a photographed OMR sheet")
+    parser.add_argument("image", type=Path, help="Path to the captured OMR sheet image")
+    parser.add_argument(
+        "--scale",
+        type=int,
+        default=4,
+        help="Scaling factor for the rectified sheet relative to the PDF units",
+    )
+    parser.add_argument(
+        "--fill-threshold",
+        type=float,
+        default=0.45,
+        help="Fill ratio threshold for considering a bubble marked",
+    )
+    parser.add_argument(
+        "--roll-threshold",
+        type=float,
+        default=0.35,
+        help="Fill ratio threshold for selecting roll number digits",
+    )
+    parser.add_argument(
+        "--output-json",
+        type=Path,
+        default=None,
+        help="Optional path to save the extracted data as JSON",
+    )
+    parser.add_argument(
+        "--debug-dir",
+        type=Path,
+        default=None,
+        help="Directory to store intermediate debug images",
+    )
+    parser.add_argument(
+        "--visualize",
+        action="store_true",
+        help="Save an annotated image with detected selections",
+    )
+    return parser.parse_args()
+
+
+def order_points(pts: np.ndarray) -> np.ndarray:
+    """Order four corner points (top-left, top-right, bottom-right, bottom-left)."""
+
+    rect = np.zeros((4, 2), dtype="float32")
+    s = pts.sum(axis=1)
+    rect[0] = pts[np.argmin(s)]  # top-left
+    rect[2] = pts[np.argmax(s)]  # bottom-right
+
+    diff = np.diff(pts, axis=1)
+    rect[1] = pts[np.argmin(diff)]  # top-right
+    rect[3] = pts[np.argmax(diff)]  # bottom-left
+    return rect
+
+
+def find_anchor_squares(image: np.ndarray) -> np.ndarray:
+    """Locate the four corner anchor squares on the OMR sheet."""
+
+    gray = cv2.cvtColor(image, cv2.COLOR_BGR2GRAY)
+    blurred = cv2.GaussianBlur(gray, (5, 5), 0)
+    binary = cv2.adaptiveThreshold(
+        blurred,
+        255,
+        cv2.ADAPTIVE_THRESH_GAUSSIAN_C,
+        cv2.THRESH_BINARY_INV,
+        41,
+        5,
+    )
+    kernel = cv2.getStructuringElement(cv2.MORPH_RECT, (5, 5))
+    closed = cv2.morphologyEx(binary, cv2.MORPH_CLOSE, kernel, iterations=2)
+
+    contours, _ = cv2.findContours(closed, cv2.RETR_EXTERNAL, cv2.CHAIN_APPROX_SIMPLE)
+    min_area = 0.002 * image.shape[0] * image.shape[1]
+    squares = []
+
+    for contour in contours:
+        area = cv2.contourArea(contour)
+        if area < min_area:
+            continue
+
+        peri = cv2.arcLength(contour, True)
+        approx = cv2.approxPolyDP(contour, 0.02 * peri, True)
+        if len(approx) != 4:
+            continue
+
+        # Ensure the contour is roughly square
+        pts = approx.reshape(4, 2)
+        _, _, w, h = cv2.boundingRect(pts.astype(np.int32))
+        ratio = w / float(h)
+        if 0.6 < ratio < 1.4:
+            squares.append((area, pts.astype("float32")))
+
+    if len(squares) < 4:
+        raise RuntimeError("Failed to locate the four anchor squares on the sheet")
+
+    # Select the four largest squares (anchors)
+    squares.sort(key=lambda x: x[0], reverse=True)
+    anchors = np.array([sq[1] for sq in squares[:4]])
+    return anchors
+
+
+def compute_warp(
+    image: np.ndarray, anchors: np.ndarray, output_size: Tuple[int, int]
+) -> np.ndarray:
+    """Warp the perspective using the detected anchors."""
+
+    # Average the points from the four contours to mitigate contour ordering issues
+    averaged_points = np.array([anchor.mean(axis=0) for anchor in anchors], dtype="float32")
+    rect = order_points(averaged_points)
+
+    (max_width, max_height) = output_size
+    destination = np.array(
+        [
+            [0, 0],
+            [max_width - 1, 0],
+            [max_width - 1, max_height - 1],
+            [0, max_height - 1],
+        ],
+        dtype="float32",
+    )
+
+    transform = cv2.getPerspectiveTransform(rect, destination)
+    warped = cv2.warpPerspective(image, transform, (max_width, max_height))
+    return warped
+
+
+def build_layout(scale: int = 4) -> Tuple[List[Bubble], Tuple[int, int]]:
+    """Replicate the generator geometry and return a list of bubbles."""
+
+    # Page and drawing parameters (in PDF points)
+    page_width, page_height = 612, 792  # letter size in points
+    square_size = 10
+    margin = 50
+    num_squares_width = 4
+
+    bubble_radius = 8
+    bubble_spacing_y = 25
+    bubble_spacing_x = bubble_radius * 3
+
+    available_width = page_width - (2 * margin)
+    spacing_x = available_width / (num_squares_width - 1) if num_squares_width > 1 else 0
+    spacing_y = spacing_x
+
+    start_x = margin
+    start_y = margin
+    end_y = page_height - margin
+
+    total_rows = int((page_height - 2 * margin) / spacing_y) + 1
+    bubbles_start_y = start_y + (total_rows - 1) * spacing_y
+
+    bubbles: List[Bubble] = []
+
+    # Roll number configuration
+    num_roll_rows = 10
+    roll_label_row = 0
+    roll_start_row = 1
+    questions_gap_row = 11
+    questions_label_row = 12
+    questions_start_row = 13
+
+    gap_center_x = start_x + (0 + 0.5) * spacing_x
+    total_width = 3 * bubble_spacing_x
+    gap_start_x = gap_center_x - total_width / 2
+
+    # Roll number bubbles (3 digit columns)
+    for digit_col in range(3):
+        bubble_x = gap_start_x + digit_col * bubble_spacing_x
+        for digit in range(num_roll_rows):
+            bubble_y = bubbles_start_y - ((roll_start_row + digit) * bubble_spacing_y)
+            bubbles.append(
+                Bubble(
+                    kind="roll",
+                    center=(bubble_x, bubble_y),
+                    radius=bubble_radius,
+                    metadata={"column": digit_col, "digit": digit},
+                )
+            )
+
+    # Question bubbles across all columns
+    question_number = 1
+    for col_gap in range(num_squares_width - 1):
+        gap_center_x = start_x + (col_gap + 0.5) * spacing_x
+        gap_start_x = gap_center_x - total_width / 2
+        question_label_x = gap_start_x - 25  # unused here but kept for completeness
+
+        if col_gap == 0:
+            start_row = questions_start_row
+        else:
+            start_row = 0
+
+        bubble_y = bubbles_start_y - (start_row * bubble_spacing_y)
+        row_index = start_row
+
+        while bubble_y >= start_y:
+            for bubble_idx, option in enumerate("ABCD"):
+                bubble_x = gap_start_x + bubble_idx * bubble_spacing_x
+                bubbles.append(
+                    Bubble(
+                        kind="question",
+                        center=(bubble_x, bubble_y),
+                        radius=bubble_radius,
+                        metadata={
+                            "question": question_number,
+                            "option": option,
+                            "column": col_gap,
+                            "row": row_index,
+                        },
+                    )
+                )
+            bubble_y -= bubble_spacing_y
+            row_index += 1
+            question_number += 1
+
+    # Convert PDF coordinates to image coordinates (top-left origin) and scale
+    scaled_bubbles: List[Bubble] = []
+    for bubble in bubbles:
+        x_pdf, y_pdf = bubble.center
+        x_img = int(round(x_pdf * scale))
+        y_img = int(round((page_height - y_pdf) * scale))
+        radius_img = int(round(bubble.radius * scale))
+        metadata = dict(bubble.metadata)
+        scaled_bubbles.append(
+            Bubble(
+                kind=bubble.kind,
+                center=(x_img, y_img),
+                radius=radius_img,
+                metadata=metadata,
+            )
+        )
+
+    output_size = (int(page_width * scale), int(page_height * scale))
+    return scaled_bubbles, output_size
+
+
+def measure_bubble_scores(gray: np.ndarray, bubbles: List[Bubble]) -> None:
+    """Compute fill scores for each bubble on the rectified sheet."""
+
+    for bubble in bubbles:
+        x, y = bubble.center
+        radius = max(3, int(bubble.radius * 0.65))
+
+        x0 = max(0, x - radius)
+        y0 = max(0, y - radius)
+        x1 = min(gray.shape[1], x + radius + 1)
+        y1 = min(gray.shape[0], y + radius + 1)
+        if x1 <= x0 or y1 <= y0:
+            bubble.score = 0.0
+            continue
+
+        roi = gray[y0:y1, x0:x1]
+        mask = np.zeros_like(roi, dtype=np.uint8)
+        cv2.circle(mask, (x - x0, y - y0), radius, 1, -1)
+        mask_area = int(mask.sum())
+        if mask_area == 0:
+            bubble.score = 0.0
+            continue
+
+        inverted = 255 - roi
+        score = float((inverted * mask).sum()) / (255.0 * mask_area)
+        bubble.score = score
+
+
+def evaluate_roll_number(
+    bubbles: List[Bubble], roll_threshold: float
+) -> Dict[str, object]:
+    """Determine the roll number digits based on the bubble scores."""
+
+    columns: Dict[int, List[Bubble]] = {0: [], 1: [], 2: []}
+    for bubble in bubbles:
+        if bubble.kind == "roll":
+            columns[bubble.metadata["column"]].append(bubble)
+
+    roll_digits: List[str] = []
+    column_scores: Dict[int, Dict[str, float]] = {}
+
+    for column_idx, items in columns.items():
+        items.sort(key=lambda b: b.metadata["digit"])  # ensure 0-9 order
+        scores = {str(b.metadata["digit"]): b.score for b in items}
+        column_scores[column_idx] = scores
+        if not items:
+            roll_digits.append("?")
+            continue
+
+        best = max(items, key=lambda b: b.score)
+        if best.score >= roll_threshold:
+            roll_digits.append(str(best.metadata["digit"]))
+        else:
+            roll_digits.append("?")
+
+    return {
+        "digits": roll_digits,
+        "string": "".join(roll_digits),
+        "columns": column_scores,
+    }
+
+
+def evaluate_questions(
+    bubbles: List[Bubble], fill_threshold: float
+) -> Dict[int, Dict[str, object]]:
+    """Evaluate answer selections for each question."""
+
+    grouped: Dict[int, List[Bubble]] = {}
+    for bubble in bubbles:
+        if bubble.kind != "question":
+            continue
+        q = int(bubble.metadata["question"])
+        grouped.setdefault(q, []).append(bubble)
+
+    results: Dict[int, Dict[str, object]] = {}
+
+    for question, items in sorted(grouped.items()):
+        items.sort(key=lambda b: b.metadata["option"])
+        option_scores = {b.metadata["option"]: b.score for b in items}
+        filled = [b for b in items if b.score >= fill_threshold]
+
+        if not filled:
+            status = "blank"
+            selected = None
+        elif len(filled) == 1:
+            status = "single"
+            selected = filled[0].metadata["option"]
+        else:
+            status = "multiple"
+            selected = [b.metadata["option"] for b in filled]
+
+        results[question] = {
+            "question": question,
+            "status": status,
+            "selected": selected,
+            "scores": option_scores,
+        }
+
+    return results
+
+
+def visualize_results(
+    warped: np.ndarray,
+    bubbles: List[Bubble],
+    roll_result: Dict[str, object],
+    question_results: Dict[int, Dict[str, object]],
+    debug_dir: Path,
+) -> None:
+    """Save an annotated overlay showing detected selections."""
+
+    overlay = warped.copy()
+    for bubble in bubbles:
+        center = tuple(map(int, bubble.center))
+        outer_radius = int(max(4, bubble.radius))
+        inner_radius = int(max(2, bubble.radius * 0.6))
+
+        color = (255, 165, 0)  # default orange for reference
+        thickness = 2
+
+        if bubble.kind == "question":
+            q = int(bubble.metadata["question"])
+            option = bubble.metadata["option"]
+            result = question_results.get(q)
+            if result:
+                if result["status"] == "single" and result["selected"] == option:
+                    color = (0, 255, 0)
+                    thickness = -1
+                elif result["status"] == "multiple" and option in result.get("selected", []):
+                    color = (0, 255, 255)
+                    thickness = -1
+                elif result["status"] == "blank":
+                    color = (0, 0, 255)
+                    thickness = 2
+        else:
+            column = bubble.metadata.get("column")
+            digit = str(bubble.metadata.get("digit"))
+            selected_digit = roll_result["digits"][column]
+            if selected_digit == digit:
+                color = (255, 0, 255)
+                thickness = -1
+
+        cv2.circle(overlay, center, outer_radius, color, 2)
+        if thickness < 0:
+            cv2.circle(overlay, center, inner_radius, color, thickness)
+
+    debug_dir.mkdir(parents=True, exist_ok=True)
+    cv2.imwrite(str(debug_dir / "annotated_results.png"), overlay)
+
+
+def save_debug_images(
+    debug_dir: Path,
+    original: np.ndarray,
+    warped: np.ndarray,
+    warped_gray: np.ndarray,
+) -> None:
+    debug_dir.mkdir(parents=True, exist_ok=True)
+    cv2.imwrite(str(debug_dir / "original.jpg"), original)
+    cv2.imwrite(str(debug_dir / "warped.jpg"), warped)
+    cv2.imwrite(str(debug_dir / "warped_gray.jpg"), warped_gray)
+
+
+def process_sheet(args: argparse.Namespace) -> Dict[str, object]:
+    bubbles_layout, output_size = build_layout(scale=args.scale)
+
+    image = cv2.imread(str(args.image))
+    if image is None:
+        raise FileNotFoundError(f"Unable to read image: {args.image}")
+
+    anchors = find_anchor_squares(image)
+    warped = compute_warp(image, anchors, output_size)
+
+    warped_gray = cv2.cvtColor(warped, cv2.COLOR_BGR2GRAY)
+    blurred = cv2.GaussianBlur(warped_gray, (5, 5), 0)
+    measure_bubble_scores(blurred, bubbles_layout)
+
+    roll_result = evaluate_roll_number(bubbles_layout, args.roll_threshold)
+    question_results = evaluate_questions(bubbles_layout, args.fill_threshold)
+
+    if args.debug_dir:
+        save_debug_images(args.debug_dir, image, warped, warped_gray)
+        if args.visualize:
+            visualize_results(warped, bubbles_layout, roll_result, question_results, args.debug_dir)
+
+    # Prepare a lightweight summary for JSON export
+    summary = {
+        "image": str(args.image),
+        "roll_number": roll_result,
+        "questions": question_results,
+        "parameters": {
+            "scale": args.scale,
+            "fill_threshold": args.fill_threshold,
+            "roll_threshold": args.roll_threshold,
+        },
+    }
+
+    if args.output_json:
+        args.output_json.parent.mkdir(parents=True, exist_ok=True)
+        with args.output_json.open("w", encoding="utf-8") as f:
+            json.dump(summary, f, indent=2)
+
+    return summary
+
+
+def main() -> None:
+    args = parse_args()
+    summary = process_sheet(args)
+
+    print("Roll Number:", summary["roll_number"]["string"])
+    print("Digits:", summary["roll_number"]["digits"])
+    print("Questions evaluated:", len(summary["questions"]))
+
+    for question, data in list(summary["questions"].items())[:10]:
+        print(
+            f"Q{question:02d}: status={data['status']}, selected={data['selected']}, scores={data['scores']}"
+        )
+
+    if len(summary["questions"]) > 10:
+        print("... (truncated)")
+
+
+if __name__ == "__main__":
+    main()

--- a/test_omr_pipeline.py
+++ b/test_omr_pipeline.py
@@ -1,0 +1,409 @@
+#!/usr/bin/env python3
+"""End-to-end test script for OMR sheet generation and processing."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import random
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, List, Tuple
+
+import cv2
+import numpy as np
+
+from omr_sheet_generator import create_omr_sheet_pdf
+from omr_processor import OMRProcessor
+import omr_processor2
+
+
+PAGE_WIDTH = 612
+PAGE_HEIGHT = 792
+SQUARE_SIZE = 10
+MARGIN = 50
+NUM_SQUARES_WIDTH = 4
+BUBBLE_RADIUS = 8
+BUBBLE_SPACING_Y = 25
+BUBBLE_SPACING_X = BUBBLE_RADIUS * 3
+NUM_ROLL_ROWS = 10
+ROLL_LABEL_ROW = 0
+ROLL_START_ROW = 1
+QUESTIONS_GAP_ROW = 11
+QUESTIONS_LABEL_ROW = 12
+QUESTIONS_START_ROW = 13
+
+
+@dataclass
+class SheetData:
+    image_path: Path
+    pdf_path: Path
+    expected_roll_digits: List[int]
+    expected_answers: Dict[int, str]
+
+
+def pdf_point_to_image(x: float, y: float, scale: int) -> Tuple[int, int]:
+    """Convert PDF coordinates (origin bottom-left) to image coords (origin top-left)."""
+
+    return int(round(x * scale)), int(round((PAGE_HEIGHT - y) * scale))
+
+
+def draw_rectangle(image: np.ndarray, bottom_left: Tuple[float, float], size: float, scale: int, color: Tuple[int, int, int], fill: bool) -> None:
+    x, y = bottom_left
+    top_left_img = pdf_point_to_image(x, y + size, scale)
+    bottom_right_img = pdf_point_to_image(x + size, y, scale)
+    thickness = -1 if fill else 2
+    cv2.rectangle(image, top_left_img, bottom_right_img, color, thickness)
+
+
+def generate_random_sheet(artifacts_dir: Path, scale: int = 4, seed: int | None = 1234) -> SheetData:
+    """Use the sheet generator layout to create a randomly filled synthetic sheet image."""
+
+    rng = random.Random(seed)
+
+    pdf_path = artifacts_dir / "synthetic_sheet.pdf"
+    pdf_path.parent.mkdir(parents=True, exist_ok=True)
+    create_omr_sheet_pdf(str(pdf_path))
+
+    width_px = int(PAGE_WIDTH * scale)
+    height_px = int(PAGE_HEIGHT * scale)
+    image = np.full((height_px, width_px, 3), 255, dtype=np.uint8)
+
+    available_width = PAGE_WIDTH - (2 * MARGIN)
+    spacing_x = available_width / (NUM_SQUARES_WIDTH - 1) if NUM_SQUARES_WIDTH > 1 else 0
+    spacing_y = spacing_x
+
+    start_x = MARGIN
+    start_y = MARGIN
+    end_x = PAGE_WIDTH - MARGIN
+    end_y = PAGE_HEIGHT - MARGIN
+
+    # Draw positioning squares (anchors and grid markers)
+    y = start_y
+    row_count = 0
+    last_row = int((end_y - start_y) / spacing_y)
+    while y <= end_y:
+        x = start_x
+        square_count = 0
+        while square_count < NUM_SQUARES_WIDTH:
+            is_corner = (
+                (row_count == 0 or row_count == last_row)
+                and (square_count == 0 or square_count == NUM_SQUARES_WIDTH - 1)
+            )
+            current_size = SQUARE_SIZE * 2 if is_corner else SQUARE_SIZE
+            half_size = current_size / 2
+            bottom_left = (x - half_size, y - half_size)
+            draw_rectangle(image, bottom_left, current_size, scale, (0, 0, 0), fill=True)
+
+            if is_corner:
+                inner_margin = current_size * 0.3
+                inner_size = current_size - 2 * inner_margin
+                if inner_size > 0:
+                    inner_bottom_left = (
+                        bottom_left[0] + inner_margin,
+                        bottom_left[1] + inner_margin,
+                    )
+                    draw_rectangle(image, inner_bottom_left, inner_size, scale, (255, 255, 255), fill=True)
+
+            x += spacing_x
+            square_count += 1
+        y += spacing_y
+        row_count += 1
+
+    total_rows = int((PAGE_HEIGHT - 2 * MARGIN) / spacing_y) + 1
+    bubbles_start_y = start_y + (total_rows - 1) * spacing_y
+
+    gap_center_x = start_x + (0 + 0.5) * spacing_x
+    total_width = 3 * BUBBLE_SPACING_X
+    gap_start_x = gap_center_x - total_width / 2
+
+    # Draw headers
+    roll_label_y = bubbles_start_y - (ROLL_LABEL_ROW * BUBBLE_SPACING_Y)
+    roll_label_pos = pdf_point_to_image(gap_start_x, roll_label_y - 3, scale)
+    cv2.putText(image, "Roll No.", roll_label_pos, cv2.FONT_HERSHEY_SIMPLEX, 0.6 * scale / 4, (0, 0, 0), 2)
+
+    questions_label_y = bubbles_start_y - (QUESTIONS_LABEL_ROW * BUBBLE_SPACING_Y)
+    questions_label_pos = pdf_point_to_image(gap_start_x, questions_label_y - 3, scale)
+    cv2.putText(image, "Questions", questions_label_pos, cv2.FONT_HERSHEY_SIMPLEX, 0.6 * scale / 4, (0, 0, 0), 2)
+
+    # Draw digit labels
+    label_x = gap_start_x - 25
+    for digit in range(NUM_ROLL_ROWS):
+        bubble_y = bubbles_start_y - ((ROLL_START_ROW + digit) * BUBBLE_SPACING_Y)
+        text_pos = pdf_point_to_image(label_x, bubble_y - 3, scale)
+        cv2.putText(image, str(digit), text_pos, cv2.FONT_HERSHEY_SIMPLEX, 0.45 * scale / 4, (0, 0, 0), 1)
+
+    roll_digit_positions: Dict[Tuple[int, int], Tuple[int, int]] = {}
+    roll_digits: List[int] = []
+
+    for digit_col in range(3):
+        bubble_x = gap_start_x + digit_col * BUBBLE_SPACING_X
+        for digit in range(NUM_ROLL_ROWS):
+            bubble_y = bubbles_start_y - ((ROLL_START_ROW + digit) * BUBBLE_SPACING_Y)
+            center = pdf_point_to_image(bubble_x, bubble_y, scale)
+            radius = int(round(BUBBLE_RADIUS * scale))
+            cv2.circle(image, center, radius, (0, 0, 0), 2)
+            roll_digit_positions[(digit_col, digit)] = center
+
+    # Draw question bubbles and labels while recording positions
+    question_positions: Dict[int, Dict[str, Tuple[int, int]]] = {}
+    question_number = 1
+
+    for col_gap in range(NUM_SQUARES_WIDTH - 1):
+        gap_center_x = start_x + (col_gap + 0.5) * spacing_x
+        gap_start_x = gap_center_x - total_width / 2
+
+        if col_gap == 0:
+            start_row = QUESTIONS_START_ROW
+        else:
+            start_row = 0
+
+        bubble_y = bubbles_start_y - (start_row * BUBBLE_SPACING_Y)
+        row_index = start_row
+
+        while bubble_y >= start_y:
+            # Question number label
+            question_label_x = gap_start_x - 25
+            text_pos = pdf_point_to_image(question_label_x, bubble_y - 3, scale)
+            cv2.putText(
+                image,
+                str(question_number),
+                text_pos,
+                cv2.FONT_HERSHEY_SIMPLEX,
+                0.45 * scale / 4,
+                (0, 0, 0),
+                1,
+            )
+
+            question_positions[question_number] = {}
+            for idx, option in enumerate("ABCD"):
+                bubble_x = gap_start_x + idx * BUBBLE_SPACING_X
+                center = pdf_point_to_image(bubble_x, bubble_y, scale)
+                radius = int(round(BUBBLE_RADIUS * scale))
+                cv2.circle(image, center, radius, (0, 0, 0), 2)
+                question_positions[question_number][option] = center
+
+            bubble_y -= BUBBLE_SPACING_Y
+            row_index += 1
+            question_number += 1
+
+            if bubble_y < start_y:
+                break
+
+    # Randomly select filled bubbles
+    for digit_col in range(3):
+        chosen_digit = rng.randint(0, 9)
+        roll_digits.append(chosen_digit)
+        center = roll_digit_positions[(digit_col, chosen_digit)]
+        radius = int(round(BUBBLE_RADIUS * scale * 0.7))
+        cv2.circle(image, center, radius, (30, 30, 30), -1)
+
+    expected_answers: Dict[int, str] = {}
+    for question, options in question_positions.items():
+        chosen_option = rng.choice(list(options.keys()))
+        expected_answers[question] = chosen_option
+        center = options[chosen_option]
+        radius = int(round(BUBBLE_RADIUS * scale * 0.7))
+        cv2.circle(image, center, radius, (40, 40, 40), -1)
+
+    image_path = artifacts_dir / "synthetic_sheet.png"
+    cv2.imwrite(str(image_path), image)
+
+    data_path = artifacts_dir / "expected_answers.json"
+    payload = {
+        "roll_digits": roll_digits,
+        "answers": expected_answers,
+    }
+    with data_path.open("w", encoding="utf-8") as f:
+        json.dump(payload, f, indent=2)
+
+    return SheetData(
+        image_path=image_path,
+        pdf_path=pdf_path,
+        expected_roll_digits=roll_digits,
+        expected_answers=expected_answers,
+    )
+
+
+def extract_old_processor_results(processor: OMRProcessor, result: Dict[str, object]) -> Tuple[str, Dict[int, str]]:
+    corrected = result["corrected"]
+    bubble_data = result["bubble_data"]
+
+    if corrected is None or bubble_data is None:
+        raise RuntimeError("Old processor did not return corrected image or bubble data")
+
+    gray = cv2.cvtColor(corrected, cv2.COLOR_BGR2GRAY) if corrected.ndim == 3 else corrected
+
+    roll_bubbles = bubble_data["roll_numbers"]
+    question_bubbles_by_column = bubble_data["questions"]
+
+    roll_digits = ["?", "?", "?"]
+    if roll_bubbles:
+        roll_x_coords = [b["center"][0] for b in roll_bubbles]
+        min_x, max_x = min(roll_x_coords), max(roll_x_coords)
+        digit_columns = [
+            min_x + (max_x - min_x) * 0.2,
+            min_x + (max_x - min_x) * 0.5,
+            min_x + (max_x - min_x) * 0.8,
+        ]
+        digit_tolerance = 15
+
+        grouped_digits: List[List[Dict[str, object]]] = [[], [], []]
+        for bubble in roll_bubbles:
+            bx = bubble["center"][0]
+            for idx, column_x in enumerate(digit_columns):
+                if abs(bx - column_x) < digit_tolerance:
+                    grouped_digits[idx].append(bubble)
+                    break
+
+        for column_idx, bubbles in enumerate(grouped_digits):
+            bubbles.sort(key=lambda b: b["center"][1])
+            best_digit = None
+            lowest_intensity = float("inf")
+            for row_idx, bubble in enumerate(bubbles):
+                x, y = bubble["center"]
+                region_size = 8
+                x1, y1 = max(0, x - region_size), max(0, y - region_size)
+                x2, y2 = min(gray.shape[1], x + region_size), min(gray.shape[0], y + region_size)
+                roi = gray[y1:y2, x1:x2]
+                if roi.size == 0:
+                    continue
+                mean_intensity = float(np.mean(roi))
+                if mean_intensity < lowest_intensity:
+                    lowest_intensity = mean_intensity
+                    best_digit = row_idx
+            if best_digit is not None and best_digit < 10:
+                roll_digits[column_idx] = str(best_digit)
+
+    fill_threshold = processor.calculate_fill_threshold(corrected)
+    question_results: Dict[int, str] = {}
+
+    question_counts = [len(col) // 4 for col in question_bubbles_by_column]
+
+    for col_idx, col_bubbles in enumerate(question_bubbles_by_column):
+        if not col_bubbles:
+            continue
+        bubbles_by_row: Dict[int, List[Dict[str, object]]] = {}
+        question_tolerance = 15
+        for bubble in col_bubbles:
+            center_y = bubble["center"][1]
+            assigned_row = None
+            for existing_y in bubbles_by_row.keys():
+                if abs(center_y - existing_y) < question_tolerance:
+                    assigned_row = existing_y
+                    break
+            if assigned_row is None:
+                assigned_row = center_y
+                bubbles_by_row[assigned_row] = []
+            bubbles_by_row[assigned_row].append(bubble)
+
+        sorted_rows = sorted(bubbles_by_row.items(), key=lambda kv: kv[0])
+        for row_idx, (_, row_bubbles) in enumerate(sorted_rows):
+            row_bubbles.sort(key=lambda b: b["center"][0])
+            question_number = sum(question_counts[:col_idx]) + row_idx + 1
+            best_option = None
+            best_score = float("inf")
+            options = ["A", "B", "C", "D"]
+            for option_idx, bubble in enumerate(row_bubbles[:4]):
+                x, y = bubble["center"]
+                region_size = 8
+                x1, y1 = max(0, x - region_size), max(0, y - region_size)
+                x2, y2 = min(gray.shape[1], x + region_size), min(gray.shape[0], y + region_size)
+                roi = gray[y1:y2, x1:x2]
+                if roi.size == 0:
+                    continue
+                mean_intensity = float(np.mean(roi))
+                if mean_intensity < fill_threshold and mean_intensity < best_score:
+                    best_score = mean_intensity
+                    best_option = options[option_idx]
+            if best_option:
+                question_results[question_number] = best_option
+
+    return "".join(roll_digits), question_results
+
+
+def run_old_processor(image_path: Path, artifacts_dir: Path) -> Tuple[str, Dict[int, str]]:
+    old_results_dir = artifacts_dir / "old_processor"
+    old_results_dir.mkdir(parents=True, exist_ok=True)
+    processor = OMRProcessor(scans_dir=str(image_path.parent), results_dir=str(old_results_dir))
+    result = processor.process_image_stepwise(str(image_path))
+    return extract_old_processor_results(processor, result)
+
+
+def run_new_processor(image_path: Path, artifacts_dir: Path) -> Tuple[str, Dict[int, str]]:
+    debug_dir = artifacts_dir / "new_processor"
+    debug_dir.mkdir(parents=True, exist_ok=True)
+    args = argparse.Namespace(
+        image=image_path,
+        scale=4,
+        fill_threshold=0.45,
+        roll_threshold=0.35,
+        output_json=None,
+        debug_dir=debug_dir,
+        visualize=False,
+    )
+    summary = omr_processor2.process_sheet(args)
+    roll_string = summary["roll_number"]["string"]
+    question_results = {}
+    for question, data in summary["questions"].items():
+        selected = data["selected"]
+        if isinstance(selected, list):
+            if selected:
+                question_results[question] = selected[0]
+        elif isinstance(selected, str):
+            question_results[question] = selected
+    return roll_string, question_results
+
+
+def compare_results(expected: SheetData, old_result: Tuple[str, Dict[int, str]], new_result: Tuple[str, Dict[int, str]]) -> None:
+    expected_roll = "".join(str(d) for d in expected.expected_roll_digits)
+    old_roll, old_answers = old_result
+    new_roll, new_answers = new_result
+
+    print("Expected roll number:", expected_roll)
+    print("Old processor roll number:", old_roll)
+    print("New processor roll number:", new_roll)
+
+    total_questions = len(expected.expected_answers)
+    old_matches = sum(1 for q, ans in expected.expected_answers.items() if old_answers.get(q) == ans)
+    new_matches = sum(1 for q, ans in expected.expected_answers.items() if new_answers.get(q) == ans)
+
+    print(f"Questions total: {total_questions}")
+    print(f"Old processor correct answers: {old_matches}")
+    print(f"New processor correct answers: {new_matches}")
+
+    mismatches = []
+    for question in sorted(expected.expected_answers.keys()):
+        exp = expected.expected_answers[question]
+        old_ans = old_answers.get(question)
+        new_ans = new_answers.get(question)
+        if old_ans != exp or new_ans != exp:
+            mismatches.append({
+                "question": question,
+                "expected": exp,
+                "old": old_ans,
+                "new": new_ans,
+            })
+
+    comparison_path = expected.image_path.parent / "comparison.json"
+    with comparison_path.open("w", encoding="utf-8") as f:
+        json.dump({
+            "expected_roll": expected_roll,
+            "old_roll": old_roll,
+            "new_roll": new_roll,
+            "mismatches": mismatches,
+        }, f, indent=2)
+
+    print(f"Comparison saved to {comparison_path}")
+
+
+def main() -> None:
+    artifacts_dir = Path("test_artifacts")
+    sheet_data = generate_random_sheet(artifacts_dir)
+    old_result = run_old_processor(sheet_data.image_path, artifacts_dir)
+    new_result = run_new_processor(sheet_data.image_path, artifacts_dir)
+    compare_results(sheet_data, old_result, new_result)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `test_omr_pipeline.py` to synthesize a filled sheet via the generator geometry
- exercise both legacy and new OMR processors against the generated image and compare the outputs

## Testing
- python -m compileall test_omr_pipeline.py
- python test_omr_pipeline.py *(fails: ImportError: libGL.so.1)*

------
https://chatgpt.com/codex/tasks/task_e_68e443b6840c832e9a06c7919ea405b5